### PR TITLE
Add Meta-refresh based flamegpu.com/try which redirects to google colab

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,20 +7,27 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Clone the repository and checkout into the relevant branch
       - uses: actions/checkout@v2
-      - name: Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.6.x
 
-      - name: Setup Rubygems, Bundler, jekyll
+      # Install Ruby
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.3 # Check https://pages.github.com/versions/ for the current Ruby version used by gh pages.
+
+      # Install dependencies required to run jekyll build
+      - name: Install gh-pages rubygem via bundler
         run: |
+          # Update gem and bundler
           gem update --system --no-document
           gem update bundler --no-document
-          gem install jekyll bundler
+          # Set the bundle directory
           bundle config set path vendor/bundle
+          # Install Gemfile contents via bundler
           bundle install
 
-      - name: Build the website.
+      # Build the website via jekyll
+      - name: Build jekyll website with drafts
         run: bundle exec jekyll build --drafts
     

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ The website is hosted on GitHub Pages and can be found at [https://flamegpu.gith
 2. Install `bundler` (via a terminal):
 
    ```sh
-   gem install bundler jekyll
+   gem install bundler
    ```
 
 3. Install other dependencies:

--- a/try/index.md
+++ b/try/index.md
@@ -1,0 +1,8 @@
+---
+title: "Try FLAMEGPU 2"
+---
+
+You can try using FLAME GPU's Python interface at 
+<a href="https://colab.research.google.com/github/FLAMEGPU/FLAMEGPU2-tutorial-python/blob/google-colab/FLAME_GPU_2_python_tutorial.ipynb">using Google-Colab</a>.
+
+<meta http-equiv="refresh" content="0;url=https://colab.research.google.com/github/FLAMEGPU/FLAMEGPU2-tutorial-python/blob/google-colab/FLAME_GPU_2_python_tutorial.ipynb">


### PR DESCRIPTION
This is a workaround for 123reg's poor DNS-based redirect featuers.