### PR TITLE
temporarily remove 'try on colab' from the homepage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Clone the repository and checkout into the relevant branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Install Ruby
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.3 # Check https://pages.github.com/versions/ for the current Ruby version used by gh pages.
+          ruby-version: 3.3.4 # Check https://pages.github.com/versions/ for the current Ruby version used by gh pages.
 
       # Install dependencies required to run jekyll build
       - name: Install gh-pages rubygem via bundler

--- a/index.md
+++ b/index.md
@@ -10,8 +10,8 @@ header:
       url: "https://github.com/FLAMEGPU/FLAMEGPU2/"
     - label: "Docs"
       url: "https://docs.flamegpu.com"
-    - label: "Try on Colab"
-      url: "https://colab.research.google.com/github/FLAMEGPU/FLAMEGPU2-tutorial-python/blob/google-colab/FLAME_GPU_2_python_tutorial.ipynb"
+    # - label: "Try on Colab"
+      # url: "https://colab.research.google.com/github/FLAMEGPU/FLAMEGPU2-tutorial-python/blob/google-colab/FLAME_GPU_2_python_tutorial.ipynb"
 excerpt: "The Flexible Large-scale Agent Modelling Environment for the Graphics Processing Unit (GPU)"
 feature_row:
   - image_path: /assets/images/gpu_birds_square.png


### PR DESCRIPTION
temporarily remove 'try on colab' from the homepage

Colab updates seem to have broken compilation, and we are unable to get logs to fix it until we port to jitify2?

![image](https://github.com/user-attachments/assets/f8bba5d0-c5f0-48e7-875c-404822829c7f)

Also version numbers in build CI workflow