### PR TITLE
Licence update to AGPL + Commercial and CLA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem "github-pages", group: :jekyll_plugins
 # To upgrade, run `bundle update`.
 
 gem "minimal-mistakes-jekyll"
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # The following plugins are automatically loaded by the theme-gem:
 #   gem "jekyll-paginate"

--- a/download/cla-individual.md
+++ b/download/cla-individual.md
@@ -1,21 +1,19 @@
 ---
 title: "Contributor Licence Agreement"
-permalink: "download/cla"
+permalink: "cla"
 ---
 
 # Contributor Licence Agreement
 
 ## Individual Contributor Exclusive License Agreement
 
-## (including the Traditional Patent License OPTION)
-
 Thank you for your interest in contributing to University of Sheffield's FLAME GPU Software ("We" or "Us").
 
-The purpose of this contributor agreement ("Agreement") is to clarify and document the rights granted by contributors to Us. To make this document effective, please follow the instructions at https://github.com/FLAMEGPU.
+The purpose of this contributor agreement ("Agreement") is to clarify and document the rights granted by contributors to Us. To make this document effective, please follow the instructions via our CLA Bot when submitting a pull request via https://github.com/FLAMEGPU/FLAMEGPU2/compare.
 
 ### How to use this Contributor Agreement
 
-If You are an employee and have created the Contribution as part of your employment, You need to have Your employer approve this Agreement or sign the Entity version of this document. If You do not own the Copyright in the entire work of authorship, any other author of the Contribution should also sign this – in any event, please contact Us at p.richmond@sheffield.ac.uk
+If You are an employee and have created the Contribution as part of your employment, You need to have Your employer approve this Agreement or sign the Entity version of this document by contacting p.richmond@sheffield.ac.uk. Entity contributions can not be processed via the CLA bot. If You do not own the Copyright in the entire work of authorship, any other author of the Contribution should also sign this – in any event, please contact Us at p.richmond@sheffield.ac.uk
 
 ### 1\. Definitions
 
@@ -93,7 +91,7 @@ IF THE DISCLAIMER AND DAMAGE WAIVER MENTIONED IN SECTION 4. AND SECTION 5. CANNO
 
 ### 8 Miscellaneous
 
-8.1 This Agreement and all disputes, claims, actions, suits or other proceedings arising out of this agreement or relating in any way to it shall be governed by the laws of Worldwide excluding its private international law provisions.
+8.1 This Agreement and all disputes, claims, actions, suits or other proceedings arising out of this agreement or relating in any way to it shall be governed by the laws of the United Kingdom of Great Britain and Northern Ireland excluding its private international law provisions.
 
 8.2 This Agreement sets out the entire agreement between You and Us for Your Contributions to Us and overrides all other agreements or understandings.
 

--- a/download/cla-individual.md
+++ b/download/cla-individual.md
@@ -9,7 +9,7 @@ permalink: "cla"
 
 Thank you for your interest in contributing to University of Sheffield's FLAME GPU Software ("We" or "Us").
 
-The purpose of this contributor agreement ("Agreement") is to clarify and document the rights granted by contributors to Us. To make this document effective, please follow the instructions via our CLA Bot when submitting a pull request via https://github.com/FLAMEGPU/FLAMEGPU2/compare.
+The purpose of this contributor agreement ("Agreement") is to clarify and document the rights granted by contributors to Us. To make this document effective, please follow the instructions via our CLA Bot when submitting a pull request via [https://github.com/FLAMEGPU/FLAMEGPU2/compare](https://github.com/FLAMEGPU/FLAMEGPU2/compare).
 
 ### How to use this Contributor Agreement
 

--- a/download/cla-individual.md
+++ b/download/cla-individual.md
@@ -13,7 +13,7 @@ The purpose of this contributor agreement ("Agreement") is to clarify and docume
 
 ### How to use this Contributor Agreement
 
-If You are an employee and have created the Contribution as part of your employment, You need to have Your employer approve this Agreement or sign the Entity version of this document by contacting p.richmond@sheffield.ac.uk. Entity contributions can not be processed via the CLA bot. If You do not own the Copyright in the entire work of authorship, any other author of the Contribution should also sign this – in any event, please contact Us at p.richmond@sheffield.ac.uk
+If You are an employee and have created the Contribution as part of your employment, You need to have Your employer approve this Agreement or sign the Entity version of this document by contacting [p.richmond@sheffield.ac.uk](mailto:p.richmond@sheffield.ac.uk). Entity contributions can not be processed via the CLA bot. If You do not own the Copyright in the entire work of authorship, any other author of the Contribution should also sign this – in any event, please contact Us at [p.richmond@sheffield.ac.uk](mailto:p.richmond@sheffield.ac.uk).
 
 ### 1\. Definitions
 

--- a/download/cla-individual.md
+++ b/download/cla-individual.md
@@ -1,0 +1,104 @@
+---
+title: "Contributor Licence Agreement"
+permalink: "download/cla"
+---
+
+# Contributor Licence Agreement
+
+## Individual Contributor Exclusive License Agreement
+
+## (including the Traditional Patent License OPTION)
+
+Thank you for your interest in contributing to University of Sheffield's FLAME GPU Software ("We" or "Us").
+
+The purpose of this contributor agreement ("Agreement") is to clarify and document the rights granted by contributors to Us. To make this document effective, please follow the instructions at https://github.com/FLAMEGPU.
+
+### How to use this Contributor Agreement
+
+If You are an employee and have created the Contribution as part of your employment, You need to have Your employer approve this Agreement or sign the Entity version of this document. If You do not own the Copyright in the entire work of authorship, any other author of the Contribution should also sign this – in any event, please contact Us at p.richmond@sheffield.ac.uk
+
+### 1\. Definitions
+
+**"You"** means the individual Copyright owner who Submits a Contribution to Us.
+
+**"Legal Entity"** means an entity that is not a natural person.
+
+**"Affiliate"** means any other Legal Entity that controls, is controlled by, or under common control with that Legal Entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such Legal Entity, whether by contract or otherwise, (ii) ownership of fifty percent (50%) or more of the outstanding shares or securities that vote to elect the management or other persons who direct such Legal Entity or (iii) beneficial ownership of such entity.
+
+**"Contribution"** means any original work of authorship, including any original modifications or additions to an existing work of authorship, Submitted by You to Us, in which You own the Copyright.
+
+**"Copyright"** means all rights protecting works of authorship, including copyright, moral and neighboring rights, as appropriate, for the full term of their existence.
+
+**"Material"** means the software or documentation made available by Us to third parties. When this Agreement covers more than one software project, the Material means the software or documentation to which the Contribution was Submitted. After You Submit the Contribution, it may be included in the Material.
+
+**"Submit"** means any act by which a Contribution is transferred to Us by You by means of tangible or intangible media, including but not limited to electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Us, but excluding any transfer that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+**"Documentation"** means any non-software portion of a Contribution.
+
+### 2\. License grant
+
+#### 2.1 Copyright license to Us
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us a worldwide, royalty-free, Exclusive, perpetual and irrevocable (except as stated in Section 8.2) license, with the right to transfer an unlimited number of non-exclusive licenses or to grant sublicenses to third parties, under the Copyright covering the Contribution to use the Contribution by all means, including, but not limited to:
+
+* publish the Contribution,
+* modify the Contribution,
+* prepare derivative works based upon or containing the Contribution and/or to combine the Contribution with other Materials,
+* reproduce the Contribution in original or modified form,
+* distribute, to make the Contribution available to the public, display and publicly perform the Contribution in original or modified form.
+
+#### 2.2 Moral rights
+
+Moral Rights remain unaffected to the extent they are recognized and not waivable by applicable law. Notwithstanding, You may add your name to the attribution mechanism customary used in the Materials you Contribute to, such as the header of the source code files of Your Contribution, and We will respect this attribution when using Your Contribution.
+
+#### 2.3 Copyright license back to You
+
+Upon such grant of rights to Us, We immediately grant to You a worldwide, royalty-free, non-exclusive, perpetual and irrevocable license, with the right to transfer an unlimited number of non-exclusive licenses or to grant sublicenses to third parties, under the Copyright covering the Contribution to use the Contribution by all means, including, but not limited to:
+
+* publish the Contribution,
+* modify the Contribution,
+* prepare derivative works based upon or containing the Contribution and/or to combine the Contribution with other Materials,
+* reproduce the Contribution in original or modified form,
+* distribute, to make the Contribution available to the public, display and publicly perform the Contribution in original or modified form.
+
+This license back is limited to the Contribution and does not provide any rights to the Material.
+
+### 3\. Patents
+
+#### 3.1 Patent license
+
+Subject to the terms and conditions of this Agreement You hereby grant to Us and to recipients of Materials distributed by Us a worldwide, royalty-free, non-exclusive, perpetual and irrevocable (except as stated in Section 3.2) patent license, with the right to transfer an unlimited number of non-exclusive licenses or to grant sublicenses to third parties, to make, have made, use, sell, offer for sale, import and otherwise transfer the Contribution and the Contribution in combination with any Material (and portions of such combination). This license applies to all patents owned or controlled by You, whether already acquired or hereafter acquired, that would be infringed by making, having made, using, selling, offering for sale, importing or otherwise transferring of Your Contribution(s) alone or by combination of Your Contribution(s) with any Material.
+
+#### 3.2 Revocation of patent license
+
+You reserve the right to revoke the patent license stated in section 3.1 if We make any infringement claim that is targeted at your Contribution and not asserted for a Defensive Purpose. An assertion of claims of the Patents shall be considered for a "Defensive Purpose" if the claims are asserted against an entity that has filed, maintained, threatened, or voluntarily participated in a patent infringement lawsuit against Us or any of Our licensees.
+
+### 4. Disclaimer
+
+THE CONTRIBUTION IS PROVIDED "AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTY OF SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE EXPRESSLY DISCLAIMED BY YOU TO US AND BY US TO YOU. TO THE EXTENT THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY IS LIMITED IN DURATION AND EXTENT TO THE MINIMUM PERIOD AND EXTENT PERMITTED BY LAW.
+
+### 5. Consequential damage waiver
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU OR WE BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF ANTICIPATED SAVINGS, LOSS OF DATA, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL AND EXEMPLARY DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR OTHERWISE) UPON WHICH THE CLAIM IS BASED.
+
+### 6. Approximation of disclaimer and damage waiver
+
+IF THE DISCLAIMER AND DAMAGE WAIVER MENTIONED IN SECTION 4. AND SECTION 5. CANNOT BE GIVEN LEGAL EFFECT UNDER APPLICABLE LOCAL LAW, REVIEWING COURTS SHALL APPLY LOCAL LAW THAT MOST CLOSELY APPROXIMATES AN ABSOLUTE WAIVER OF ALL CIVIL OR CONTRACTUAL LIABILITY IN CONNECTION WITH THE CONTRIBUTION.
+
+### 7. Term
+
+7.1 This Agreement shall come into effect upon Your acceptance of the terms and conditions.
+
+7.3 In the event of a termination of this Agreement Sections 4, 5, 6, 7 and 8 shall survive such termination and shall remain in full force thereafter. For the avoidance of doubt, Free and Open Source Software (sub)licenses that have already been granted for Contributions at the date of the termination shall remain in full force after the termination of this Agreement.
+
+### 8 Miscellaneous
+
+8.1 This Agreement and all disputes, claims, actions, suits or other proceedings arising out of this agreement or relating in any way to it shall be governed by the laws of Worldwide excluding its private international law provisions.
+
+8.2 This Agreement sets out the entire agreement between You and Us for Your Contributions to Us and overrides all other agreements or understandings.
+
+8.3 In case of Your death, this agreement shall continue with Your heirs. In case of more than one heir, all heirs must exercise their rights through a commonly authorized person.
+
+8.4 If any provision of this Agreement is found void and unenforceable, such provision will be replaced to the extent possible with a provision that comes closest to the meaning of the original provision and that is enforceable. The terms and conditions set forth in this Agreement shall apply notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the maximum extent possible under law.
+
+8.5 You agree to notify Us of any facts or circumstances of which you become aware that would make this Agreement inaccurate in any respect.

--- a/download/index.md
+++ b/download/index.md
@@ -14,7 +14,7 @@ Please see the [Release Notes](https://github.com/FLAMEGPU/FLAMEGPU2/releases/la
 
 To build FLAME GPU 2+ or develop using C++, you can either start by consider starting with one of the standalone [models](../models), or create a new standalone model based on the [template repository](https://github.com/FLAMEGPU/FLAMEGPU2-example-template) or by downloading and building the main [FLAME GPU 2](https://github.com/FLAMEGPU/FLAMEGPU2) project and follow the instructions in the readme. FLAME GPU 2 uses [CMake](https://cmake.org) as a cross-platform build system, with support for Windows via Visual Studio and for Linux systems via make, with support for CUDA 12.0+. Please see the [readme](https://github.com/FLAMEGPU/FLAMEGPU2) for further information on the dependencies of FLAME GPU 2 and the model development process.
 
-*Note: FLAME GPU 2 is released under a [dual licence of AGPL v3.0 and a commercial licence](./licence). Pre-release versions were previously distributed under MIT. Contributions require a digital signature (via a GitHub CLA bot) of our [Contributor Licence Agreement](./cla).*
+*Note: FLAME GPU 2 is released under a [dual licence of AGPL v3.0 and a commercial licence](./licence). Pre-release versions were previously distributed under MIT. Contributions require a digital signature (via a GitHub CLA bot) of our [Contributor Licence Agreement](../cla).*
 
 
 

--- a/download/index.md
+++ b/download/index.md
@@ -14,16 +14,14 @@ Please see the [Release Notes](https://github.com/FLAMEGPU/FLAMEGPU2/releases/la
 
 To build FLAME GPU 2+ or develop using C++, you can either start by consider starting with one of the standalone [models](../models), or create a new standalone model based on the [template repository](https://github.com/FLAMEGPU/FLAMEGPU2-example-template) or by downloading and building the main [FLAME GPU 2](https://github.com/FLAMEGPU/FLAMEGPU2) project and follow the instructions in the readme. FLAME GPU 2 uses [CMake](https://cmake.org) as a cross-platform build system, with support for Windows via Visual Studio and for Linux systems via make, with support for CUDA 12.0+. Please see the [readme](https://github.com/FLAMEGPU/FLAMEGPU2) for further information on the dependencies of FLAME GPU 2 and the model development process.
 
-FLAME GPU 2 is released under a [dual licence of AGPL v3.0 and a commercial licence](./licence). Pre-release versions were previously distributed under MIT.
-
-*Note: FLAME GPU 2 refers to Versions 2+ as opposed to the legacy 1.x version of FLAME GPU*
+*Note: FLAME GPU 2 is released under a [dual licence of AGPL v3.0 and a commercial licence](./licence). Pre-release versions were previously distributed under MIT. Contributions require a digital signature (via a GitHub CLA bot) of our [Contributor Licence Agreement](./cla).*
 
 
 
 ## FLAME GPU 1.x (Legacy Versions)
 
 [![FLAME GPU 1 logo]({{ "/assets/images/flame_gpu_v1.jpg" | relative_url }})](https://github.com/FLAMEGPU/FLAMEGPU){: .align-right .no-shadow} 
-FLAME GPU 2 is designed on the same concepts and ideas of FLAME GPU 1 with a similar but vastly improved interface and wider variety of features. FLAME GPU 1.x releases are still available to download and use, although it should be considered legacy software and there are no plans for further development or maintenance of FLAME GPU 1.
+FLAME GPU 2 refers to Versions 2+ as opposed to the legacy 1.x version of FLAME GPU/ FLAME GPU 2 is designed on the same concepts and ideas of FLAME GPU 1 with a similar but vastly improved interface and wider variety of features. FLAME GPU 1.x releases are still available to download and use, although it should be considered legacy software and there are no plans for further development or maintenance of FLAME GPU 1.
 
 The latest release, FLAME GPU 1.5 supports CUDA 10.2 with Visual Studio 2015/2019 on windows and Make on Linux). 
 CUDA 11.0+ is unsupported.

--- a/download/index.md
+++ b/download/index.md
@@ -2,26 +2,29 @@
 title: "Download FLAME GPU"
 ---
 
-## FLAME GPU 2.x
+## FLAME GPU 2+
 
-[![FLAME GPU 2 logo]({{ "/assets/images/fgpu2_icon_256.png" | relative_url }})](https://github.com/FLAMEGPU/FLAMEGPU2){: .align-right .no-shadow}
-FLAME GPU 2 is currently in an pre-release (alpha) state, and although we hope there will not be significant changes to the API prior to a stable release there may be breaking changes as we fix issues, adjust the API and improve performance.
+The simplest and recommend way to install FLAME GPU 2+ is to install our pre-built python binary wheels using our [wheelhouse](https://whl.flamegpu.com/). E.g. to install the latest pyflamegpu build for CUDA 12.0+ with visualiastion:
 
-It is mostly feature complete with FLAME GPU 1 but may not meet the same levels of performance for all use cases.
-This is a result of the vastly more flexible interface used to template generated code.
-Performance is generally still very close to or better than FLAME GPU 1 and optimisations are always being added.
+```
+python3 -m pip install --extra-index-url https://whl.flamegpu.com/whl/cuda120-vis/ pyflamegpu
+```
 
-FLAME GPU 2 uses [CMake](https://cmake.org) as a cross-platform build system, with support for Windows via Visual Studio and for linux systems via make, with support for CUDA 11.0+.
-Please see the [readme](https://github.com/FLAMEGPU/FLAMEGPU2) for further information on the dependencies of FLAME GPU 2 and the model development process.
+Please see the [Release Notes](https://github.com/FLAMEGPU/FLAMEGPU2/releases/latest) for more information.
 
-To use FLAME GPU 2, you can either start by consider starting with one of the standalone [models](../models), or create a new standalone model based on the [template repository](https://github.com/FLAMEGPU/FLAMEGPU2-example-template) or by downloading and building the main [FLAME GPU 2](https://github.com/FLAMEGPU/FLAMEGPU2) project and follow the instructions in the readme.
+To build FLAME GPU 2+ or develop using C++, you can either start by consider starting with one of the standalone [models](../models), or create a new standalone model based on the [template repository](https://github.com/FLAMEGPU/FLAMEGPU2-example-template) or by downloading and building the main [FLAME GPU 2](https://github.com/FLAMEGPU/FLAMEGPU2) project and follow the instructions in the readme. FLAME GPU 2 uses [CMake](https://cmake.org) as a cross-platform build system, with support for Windows via Visual Studio and for Linux systems via make, with support for CUDA 12.0+. Please see the [readme](https://github.com/FLAMEGPU/FLAMEGPU2) for further information on the dependencies of FLAME GPU 2 and the model development process.
 
-Pre-built python 3.6+ binary wheels are now available on some platforms. Please see the [Release Notes](https://github.com/FLAMEGPU/FLAMEGPU2/releases/latest) for more information.
+FLAME GPU 2 is released under a [dual licence of AGPL v3.0 and a commercial licence](./licence). Pre-release versions were previously distributed under MIT.
 
-## FLAME GPU 1.x
+*Note: FLAME GPU 2 refers to Versions 2+ as opposed to the legacy 1.x version of FLAME GPU*
+
+
+
+## FLAME GPU 1.x (Legacy Versions)
 
 [![FLAME GPU 1 logo]({{ "/assets/images/flame_gpu_v1.jpg" | relative_url }})](https://github.com/FLAMEGPU/FLAMEGPU){: .align-right .no-shadow} 
-FLAME GPU 1.x releases are still available to download and use, although there are no plans for further development of FLAME GPU 1.
+FLAME GPU 2 is designed on the same concepts and ideas of FLAME GPU 1 with a similar but vastly improved interface and wider variety of features. FLAME GPU 1.x releases are still available to download and use, although it should be considered legacy software and there are no plans for further development or maintenance of FLAME GPU 1.
+
 The latest release, FLAME GPU 1.5 supports CUDA 10.2 with Visual Studio 2015/2019 on windows and Make on Linux). 
 CUDA 11.0+ is unsupported.
 

--- a/download/licence.md
+++ b/download/licence.md
@@ -1,0 +1,44 @@
+---
+title: "FLAME GPU 2 Licence"
+---
+
+The most recent (and future) versions of FLAME GPU 2 are available under a dual licence (AGPL v3.0 and commercial). Previous versions of FLAME GPU were distributed under MIT.
+
+## Why a dual licence model for FLAME GPU 2
+
+Developing and maintaining research software is hard, especially software like FLAME GPU which requires highly skilled GPU developers. Very little funding exists for development or maintenance. FLAME GPU 2 was extremely fortunate to receive a large chunk of funding for its initial development via a Research Software Engineering Fellowship. Funding to support new features is often sought through collaborative research projects with partners wishing to apply FLAME GPU to a new domain. As the software has become mature and stable it is becoming harder to seek research grants which look to add novel new features (constituting software engineering research). Instead funding is required to maintain what we already have.
+
+## Commitment to Open Source
+
+First and foremost FLAME GPU is committed to open source, in particular in ensuring that the results of FLAME GPU simulations are FAIR and that the software itself remains open and accessible, preventing it from becoming proprietary. If you use FLAME GPU as part of your research and want to publish the resulting model and outputs you can do so under the AGPL v3.0 terms.
+
+## A Commercial Licence
+
+The move towards a dual licence allows us to pursue commercial routes for FLAME GPU to generate revenue to support the software and to help understand its industrial impact. As a FLAME GPU user, this means that if you do not want to comply with the AGPL terms then a commercial licence would be required. I.e. If you want to build a model or product using FLAME GPU and distribute this without releasing the source code then a commercial would eb needed. There is not a fixed licence fee, instead this is negotiable depending on your use case and may require terms to help us understand and demonstrate the impact of the software. If you would like to find out more then please [contact us](../../contact).
+
+## FAQ
+
+**Q: Why are you changing it now?**  
+A: The software is reaching a mature and stable point where alternative sources of income are required to support its maintenance.
+
+**Q: Can I use the old MIT version?**  
+A: Of course but updates to the software will only be issued under the new licence terms.
+
+**Q: Can I have a commercial licence?**  
+A: Yes. Speak to us.
+
+**Q: Can I have a free commercial licence?**  
+A: Possibly. Speak to us.
+
+**Q: Can I fund FLAME GPUs development without a commercial licence?**  
+A: Yes of course. Speak to us.
+
+**Q: MIT was much better. Don't you agree?**  
+A: MIT is great but we need to find ways to fund FLAME GPUs development or it will lose support.
+
+**Q: Can I contribute to the software?**  
+A: Yes. See our contribution guidelines. We will require a contributor licence agreement which allows us permission to distribute any contribution under the dual licence terms.
+
+**Q: Can you tell me if my software is compliant with AGPL?**  
+We can not. You should seek specialist advice. 
+

--- a/download/license.md
+++ b/download/license.md
@@ -1,10 +1,10 @@
 ---
-title: "FLAME GPU 2 Licence"
+title: "FLAME GPU 2 License"
 ---
 
-The most recent (and future) versions of FLAME GPU 2 are available under a dual licence (AGPL v3.0 and commercial). Previous versions of FLAME GPU were distributed under MIT.
+The most recent (and future) versions of FLAME GPU 2 are available under a dual license (AGPL v3.0 and commercial). Previous versions of FLAME GPU were distributed under MIT.
 
-## Why a dual licence model for FLAME GPU 2
+## Why a dual license model for FLAME GPU 2
 
 Developing and maintaining research software is hard, especially software like FLAME GPU which requires highly skilled GPU developers. Very little funding exists for development or maintenance. FLAME GPU 2 was extremely fortunate to receive a large chunk of funding for its initial development via a Research Software Engineering Fellowship. Funding to support new features is often sought through collaborative research projects with partners wishing to apply FLAME GPU to a new domain. As the software has become mature and stable it is becoming harder to seek research grants which look to add novel new features (constituting software engineering research). Instead funding is required to maintain what we already have.
 
@@ -12,9 +12,9 @@ Developing and maintaining research software is hard, especially software like F
 
 First and foremost FLAME GPU is committed to open source, in particular in ensuring that the results of FLAME GPU simulations are FAIR and that the software itself remains open and accessible, preventing it from becoming proprietary. If you use FLAME GPU as part of your research and want to publish the resulting model and outputs you can do so under the AGPL v3.0 terms.
 
-## A Commercial Licence
+## A Commercial License
 
-The move towards a dual licence allows us to pursue commercial routes for FLAME GPU to generate revenue to support the software and to help understand its industrial impact. As a FLAME GPU user, this means that if you do not want to comply with the AGPL terms then a commercial licence would be required. I.e. If you want to build a model or product using FLAME GPU and distribute this without releasing the source code then a commercial would eb needed. There is not a fixed licence fee, instead this is negotiable depending on your use case and may require terms to help us understand and demonstrate the impact of the software. If you would like to find out more then please [contact us](../../contact).
+The move towards a dual license allows us to pursue commercial routes for FLAME GPU to generate revenue to support the software and to help understand its industrial impact. As a FLAME GPU user, this means that if you do not want to comply with the AGPL terms then a commercial license would be required. I.e. If you want to build a model or product using FLAME GPU and distribute this without releasing the source code then a commercial would eb needed. There is not a fixed license fee, instead this is negotiable depending on your use case and may require terms to help us understand and demonstrate the impact of the software. If you would like to find out more then please [contact us](../../contact).
 
 ## FAQ
 
@@ -22,22 +22,22 @@ The move towards a dual licence allows us to pursue commercial routes for FLAME 
 A: The software is reaching a mature and stable point where alternative sources of income are required to support its maintenance.
 
 **Q: Can I use the old MIT version?**  
-A: Of course but updates to the software will only be issued under the new licence terms.
+A: Of course but updates to the software will only be issued under the new license terms.
 
-**Q: Can I have a commercial licence?**  
+**Q: Can I have a commercial license?**  
 A: Yes. Speak to us.
 
-**Q: Can I have a free commercial licence?**  
+**Q: Can I have a free commercial license?**  
 A: Possibly. Speak to us.
 
-**Q: Can I fund FLAME GPUs development without a commercial licence?**  
+**Q: Can I fund FLAME GPUs development without a commercial license?**  
 A: Yes of course. Speak to us.
 
 **Q: MIT was much better. Don't you agree?**  
 A: MIT is great but we need to find ways to fund FLAME GPUs development or it will lose support.
 
 **Q: Can I contribute to the software?**  
-A: Yes. See our contribution guidelines. We will require a contributor licence agreement which allows us permission to distribute any contribution under the dual licence terms.
+A: Yes. See our [contribution guidelines](https://github.com/FLAMEGPU/FLAMEGPU2/blob/master/CONTRIBUTING.md). We will require a contributor license agreement which allows us permission to distribute any contribution under the dual license terms.
 
 **Q: Can you tell me if my software is compliant with AGPL?**  
 We can not. You should seek specialist advice. 


### PR DESCRIPTION
PR to incoorporate changes to licencing as a result of dual licence format. Merge should be delayed until release.

 - [x] Added page with descriptionof new licencing
 - [x] Updated download instructions (e.g. CUDA 12.0+ and full release rather tha alpha/RC)
 - [x] Minor fix to gem file to sort windows issue with time zones. 
 - [x] Added CLA licence which will be lcoated at https://flamegpu.com/cla